### PR TITLE
Add Pilot Protocol to P2P Networking Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - **[ZeroMQ](https://zeromq.org/)** - A high-performance messaging library often used in P2P applications.
 - **[PeerJS](https://peerjs.com/)** - A simple library for building WebRTC-based P2P applications.
 - **[Socket.IO P2P](https://github.com/socketio/socket.io-p2p)** - A P2P extension for Socket.IO that enables direct peer connections.
+- **[Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol)** - An open-source overlay network (Go, stdlib-only) built for AI agents, giving each agent a permanent virtual address, encrypted UDP tunnels, NAT traversal (STUN/hole-punching/relay), and an explicit per-peer trust model.
 
 ## Decentralized File Sharing
 


### PR DESCRIPTION
Adds Pilot Protocol (https://github.com/TeoSlayer/pilotprotocol) to the P2P Networking Libraries and Tools section.

Pilot Protocol is an open-source overlay network (Go, AGPL-3.0, zero external dependencies) purpose-built for AI agents: permanent virtual addresses, encrypted UDP tunnels (X25519 + AES-GCM), NAT traversal (STUN + hole-punching + relay fallback), and an explicit per-peer trust model decoupled from network membership.