### PR TITLE
Add meshare to Decentralized File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - **[RetroShare](https://retroshare.cc/)** - An open-source P2P communication and file-sharing platform.
 - **[Soulseek](https://www.slsknet.org/)** - A P2P file-sharing application focused on music sharing.
 - **[LimeWire (Revived)](https://www.limewire.com/)** - A new version of the classic P2P file-sharing software, focused on NFTs and digital content.
+- **[meshare](https://github.com/HassanNadeem1122/meshare)** - Zero-install P2P file sharing and static site hosting that runs entirely in the browser via WebRTC; every recipient automatically becomes a seeder for the next.
 
 ## Blockchain and P2P Networks
 


### PR DESCRIPTION
Adds [meshare](https://github.com/HassanNadeem1122/meshare) - a zero-install P2P file sharing and static site hosting tool that runs in a normal browser via WebRTC. `npx meshare ./file` gives a link; recipients download peer-to-peer and automatically become seeders for the next person. `meshare site ./folder` does the same for small static sites/games (SHA-256 verified before running, sandboxed).

Checked against CONTRIBUTING.md: active project (npm published, working live demo), single relevant entry in the correct existing section, one line, no self-promotional language, link verified live.